### PR TITLE
Contribución de Santiago Mosca

### DIFF
--- a/2024/GMG-memoria-2024.tex
+++ b/2024/GMG-memoria-2024.tex
@@ -504,6 +504,7 @@ No se publicaron trabajos sin referato.
 \subsubsection{Nacionales}
 
 \begin{enumerate}
+    \item \fullcite{mosca2024b}.
     \item \fullcite{basiuk2024}.
     \item \fullcite{cervantes2024}.
     \item \fullcite{cristal2024}.

--- a/2024/GMG-memoria-2024.tex
+++ b/2024/GMG-memoria-2024.tex
@@ -324,6 +324,9 @@ Zonco, Sofía & Beca SCyT & UTN & 12 \\
 
 % En virtud de las tareas de investigación llevadas a cabo por los becarios, todos solicitaron ingresar a la Carrera del Investigador UTN, obteniendo luego de la evaluación de sus solicitudes la categoría F (Basiuk, Petri, Recalt y Mosca).
 
+El becario Santiago Mosca solicitó evaluación en la Carrera del Investigador UTN, ascendieno a la categoría E - Orientación Ciencias de la Ingeniería y Tecnologías (Resolución C.S. N$^{\circ}$ 1456/2024, 4/09/2024).
+
+
 \section{Equipamiento e infraestructura}
 
 \subsection{Equipamiento e infraestructura principal disponible}

--- a/2024/GMG-memoria-2024.tex
+++ b/2024/GMG-memoria-2024.tex
@@ -642,6 +642,8 @@ El banco de pruebas de descarga de silos montado en los laboratorios del GMG se 
 
 M. Madrid se desempeñó como director de tesis de grado de Déborah Gozalez, alumna de la Facultad de Ciencias Exactas de la Universidad Nacional de La Plata.
 
+S. Mosca se desempeñó como tutor de práctica profesional de Romina Castro y Ayrton Arteta, alumnos de Ingeniería Mecánica de la Facultad Regional La Plata de la Universidad Tecnológica Nacional.
+
 \chapter{Vinculación con el medio socioproductivo}
 
 \section{Transferencia al medio socioproductivo}

--- a/2024/gmg-2024.bib
+++ b/2024/gmg-2024.bib
@@ -310,6 +310,26 @@
 
 
 %%  Congresos
+@article{mosca2024a,
+  title={Pervaporación de Mezclas Agua-Metanol Mediante Nanotubos de Grafeno},
+  url={https://rtyc.utn.edu.ar/index.php/ajea/article/view/1723},
+  DOI={10.33414/ajea.1723.2024},
+  number={AJEA 37},
+  journal={AJEA (Actas de Jornadas y Eventos Académicos de UTN)},
+  author={Mosca, Santiago and Carlevaro, C. Manuel and Castez, M. Federico},
+  year={2024},
+  month={10}
+}
+
+@inproceedings{mosca2024b,
+  author={Mosca, Santiago and Carlevaro, C. Manuel and Castez, M. Federico},
+  title={Pervaporaci{\'o}n de Mezclas Agua-Metanol Mediante Nanotubos de Grafeno},
+  eventtitle = {AJEA (Actas de Jornadas y Eventos Acad{\'e}micos de UTN)},
+  date = {2024-10-17/2024-10-18},
+  location = {General Pacheco, Buenos Aires},
+  year = {2024},
+}
+
 @inproceedings{basiuk2024,
   author = {Basiuk, Lucas and Carlevaro, Manuel and Irastorza, Ramiro},
   eventtitle = {AJEA (Actas de Jornadas y Eventos Acad{\'e}micos de UTN)},


### PR DESCRIPTION
Agrego tres ítems.

La categorización de 2023 como Investigador categoría F no sucedió (no sé porqué, pero no figuré en la resolución). En 2024 pedí nuevamente evaluación, obtuve categoría E. Lo agregué como "reevaluación".

Fui tutor de dos prácticas profesionales. No es relevante como una tesis de grado, pero lo agregué debajo de la tesis de Marcos.

La participación en la Jornada de Doctorandos de UTN 2024 la cité en mi CV como artículo, porque así figura el bibtex que ofrecen descargar desde la web de AJEA. Aquí la incoporé como inproceedings, pero dejé el bibtex de article original en caso de que fuera necesario o conveniente cambiarlo.